### PR TITLE
fix: Add "v4l2h264dec" support

### DIFF
--- a/appsrc.c
+++ b/appsrc.c
@@ -169,7 +169,7 @@ int gst_main(int rtp_port, char *codec, int rtp_jitter, osd_render_t osd_render,
                      rtp_port, codec + 1);
         }
 
-        char *codecs[] = { "nv%sdec", "avdec_%s" };
+        char *codecs[] = {"nv%sdec", "avdec_%s", "v4l2%sdec"};
         char *decoder = NULL;
 
         for(int i = 0; i < sizeof(codecs) / sizeof(codecs[0]); i++)


### PR DESCRIPTION
Apparently RaspberryPI 2w, 4b can utilize hardware h264 decoding with `v4l2h264dec` plugin.

Tested on the RaspberryPI 2w, although measurement is not very accurate, it shows significant difference in CPU consumption

<img width="1267" alt="Screenshot 2025-03-09 at 19 42 22" src="https://github.com/user-attachments/assets/1ca81e09-ea2b-4596-8327-10b5894a339b" />

