### PR TITLE
fix: Add "kmssink" for OSD GST

### DIFF
--- a/appsrc.c
+++ b/appsrc.c
@@ -131,6 +131,11 @@ static const char* select_osd_render(osd_render_t osd_render)
             "clockoverlay text=GL valignment=center ! glimagesink" : \
             "glimagesink";
 
+    case OSD_RENDER_KMS:
+        return osd_debug ? \
+            "glcolorconvert ! gldownload ! clockoverlay text=Auto valignment=center ! kmssink" : \
+            "glcolorconvert ! gldownload ! kmssink";
+
     case OSD_RENDER_AUTO:
     default:
         return osd_debug ? \

--- a/appsrc.c
+++ b/appsrc.c
@@ -174,7 +174,7 @@ int gst_main(int rtp_port, char *codec, int rtp_jitter, osd_render_t osd_render,
                      rtp_port, codec + 1);
         }
 
-        char *codecs[] = {"nv%sdec", "avdec_%s", "v4l2%sdec"};
+        char *codecs[] = {"nv%sdec", "v4l2%sdec", "avdec_%s"};
         char *decoder = NULL;
 
         for(int i = 0; i < sizeof(codecs) / sizeof(codecs[0]); i++)

--- a/graphengine.h
+++ b/graphengine.h
@@ -11,6 +11,7 @@ typedef enum
     OSD_RENDER_AUTO = 0,
     OSD_RENDER_XV,
     OSD_RENDER_GL,
+    OSD_RENDER_KMS,
 } osd_render_t;
 
 // Size of an array (num items.)
@@ -172,5 +173,3 @@ extern uint8_t* video_buf_ext;
 extern pthread_mutex_t video_mutex;
 
 #endif
-
-

--- a/main.c
+++ b/main.c
@@ -100,7 +100,7 @@ int main(int argc, char **argv)
     int fd;
     struct pollfd fds[1];
 
-    while ((opt = getopt(argc, argv, "hdp:P:R:45j:xaw:")) != -1) {
+    while ((opt = getopt(argc, argv, "hdp:P:R:45j:xakw:")) != -1) {
         switch (opt) {
         case 'p':
             osd_port = atoi(optarg);
@@ -132,6 +132,10 @@ int main(int argc, char **argv)
 
         case 'a':
             osd_render = OSD_RENDER_AUTO;
+            break;
+
+        case 'k':
+            osd_render = OSD_RENDER_KMS;
             break;
 
         case 'w':


### PR DESCRIPTION
On **Raspberry PI 4 B** `glimagesink` produces the image with artefacts
![screen](https://github.com/user-attachments/assets/5045284a-d9c7-440d-bd2f-717bf0afb30c)


Adding `kmssink` option helped to remove artefacts. Side note, on **Raspberry PI 4 B** OSD still works extremely slow, I don't have exact measurement, however lag is around 1-2 seconds with frame drops.

Additionally **Raspberry PI 5** failed to output anything to the display using `glimagesink`, on the other side, using `kmssink` worked fine (`autovideosink` haven't helped either), visually acceptable image/lag.  Note, **Raspberry PI 5** lacks the hardware decoder in GST1.0, so `avdec_h264` is the way. CPU usage ~25%

---

Also re-order the decoder "tries" to probe hardware decoders first and fallback to software one and a "last stand" option